### PR TITLE
Net::TCPClient#read method process data with buffer variable

### DIFF
--- a/lib/jrpc/tcp_client.rb
+++ b/lib/jrpc/tcp_client.rb
@@ -74,7 +74,8 @@ module JRPC
     def receive_response(timeout)
       timeout ||= @transport.read_timeout
       length = get_msg_length(timeout)
-      response = @transport.read(length+1, nil, timeout)
+      response = ''
+      @transport.read(length+1, response, timeout)
       raise ClientError.new('invalid response. missed comma as terminator') if response[-1] != ','
       response.chomp(',')
     rescue ::SocketError

--- a/spec/fake_transport.rb
+++ b/spec/fake_transport.rb
@@ -1,0 +1,23 @@
+class FakeTransport
+  attr_reader :read_timeout, :write_timeout
+
+  def initialize(params = {})
+    @read_timeout = params.fetch(:read_timeout, 60.0).to_f
+    @write_timeout = params.fetch(:write_timeout, 60.0).to_f
+  end
+
+  def connect; end
+
+  def write(_, write_timeout = nil)
+    @write_timeout = write_timeout if write_timeout
+  end
+
+  def read(_, buffer, read_timeout = nil)
+    @read_timeout = read_timeout if read_timeout
+    buffer << @response
+  end
+
+  def response=(str)
+    @response = str + ','
+  end
+end

--- a/spec/tcp_client_spec.rb
+++ b/spec/tcp_client_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 require 'logger'
 require 'json'
+require 'fake_transport'
 
 describe JRPC::TcpClient do
+
+  let(:socket_stub) { FakeTransport.new(read_timeout: 30, write_timeout: 60) }
 
   shared_examples :sends_request_and_receive_response do |options = {}|
     method = options.fetch(:method)
@@ -46,11 +49,12 @@ describe JRPC::TcpClient do
       expect(socket_stub).to receive(:write).with(raw_expected_request, 60).once
 
       json_result = expected_result.to_json
+      socket_stub.response = json_result
       expect(socket_stub).to receive(:read).with(1, nil, 30).exactly(json_result.size.to_s.size).times.
           and_return(
               *(json_result.size.to_s.split('') + [':'])
           )
-      expect(socket_stub).to receive(:read).with(json_result.size + 1, nil, 30).and_return(json_result + ',')
+      expect(socket_stub).to receive(:read).with(json_result.size + 1, '', 30).and_return(json_result + ',').and_call_original
 
       expect(subject).to eq JSON.parse(json_result)['result']
     end
@@ -107,7 +111,6 @@ describe JRPC::TcpClient do
     let(:client_options) { {} }
     let(:invoke_request_method) { 'sum' }
     let(:invoke_request_params) { [1, 2] }
-    let(:socket_stub) { instance_double(Net::TCPClient, read_timeout: 30, write_timeout: 60) }
 
     before do
       allow(Net::TCPClient).to receive(:new).with(any_args).once.and_return(socket_stub)
@@ -144,7 +147,6 @@ describe JRPC::TcpClient do
     let(:client_options) { {} }
     let(:invoke_notification_method) { 'sum' }
     let(:invoke_notification_params) { [1, 2] }
-    let(:socket_stub) { instance_double(Net::TCPClient, read_timeout: 30, write_timeout: 60) }
 
     before do
       allow(Net::TCPClient).to receive(:new).with(any_args).once.and_return(socket_stub)
@@ -182,7 +184,6 @@ describe JRPC::TcpClient do
     let(:client) { JRPC::TcpClient.new('127.0.0.1:1234', client_options) }
     let(:client_options) { {} }
     let(:stubbed_generated_id) { 'rspec-generated-id' }
-    let(:socket_stub) { instance_double(Net::TCPClient, read_timeout: 30, write_timeout: 60) }
 
     before do
       allow_any_instance_of(JRPC::TcpClient).to receive(:generate_id).with(no_args).and_return(stubbed_generated_id)


### PR DESCRIPTION
Due to some network problems, or wrong response length calculation(happens in yetis_node) we receive only part of response. @dmitry-sinina tested solution where we use `#read` method with buffer. And it works fine.

This PR changes a bit of `receive_response` method to use buffer variable.

This changes broke tests. `instance_double` not suits anymore. So I added fake-class to imitate `Net::TCPClient#read` method with buffer variable.

https://github.com/rocketjob/net_tcp_client/blob/v2.0.1/lib/net/tcp_client/tcp_client.rb#L628

https://apidock.com/ruby/IO/read_nonblock