### PR TITLE
use JRPC::Error as base class for JRPC::Transport::SocketBase::Error

### DIFF
--- a/lib/jrpc/transport/socket_base.rb
+++ b/lib/jrpc/transport/socket_base.rb
@@ -2,7 +2,7 @@ module JRPC
   module Transport
     class SocketBase
 
-      class Error < StandardError
+      class Error < ::JRPC::Error
       end
 
       class TimeoutError < Error


### PR DESCRIPTION
to make it easy to handle all exceptions in one liner